### PR TITLE
Support for Large Datasets

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,6 @@ config_args = {
     "fast_decoding": 1,
     "num_samples": -1,
     "large_dataset": 0,
-    "data_points": 1,
     
     # model
     "dtype": "double",
@@ -26,4 +25,5 @@ config_args = {
 
     # dataset
     "dataset": "zoo",
+    "data_points": 101,
 }

--- a/config.py
+++ b/config.py
@@ -12,7 +12,9 @@ config_args = {
     "save": 1,
     "fast_decoding": 1,
     "num_samples": -1,
-
+    "large_dataset": 0,
+    "data_points": 1,
+    
     # model
     "dtype": "double",
     "rank": 2,

--- a/datasets/hc_dataset.py
+++ b/datasets/hc_dataset.py
@@ -6,13 +6,14 @@ import numpy as np
 import torch
 import torch.utils.data as data
 
+from datasets.loading import load_data
 from datasets.triples import generate_all_triples, samples_triples
 
 
 class HCDataset(data.Dataset):
     """Hierarchical clustering dataset."""
 
-    def __init__(self, features, labels, similarities, num_samples):
+    def __init__(self, data_points, num_samples, data_dir, large_dataset):
         """Creates Hierarchical Clustering dataset with triples.
 
         @param labels: ground truth labels
@@ -20,11 +21,18 @@ class HCDataset(data.Dataset):
         @param similarities: pairwise similarities between datapoints
         @type similarities: np.array of shape (n_datapoints, n_datapoints)
         """
-        self.features = features
-        self.labels = labels
-        self.similarities = similarities
-        self.n_nodes = self.similarities.shape[0]
+
+
+        self.n_nodes = data_points
         self.triples = self.generate_triples(num_samples)
+        x, y_true, similarities = load_data(data_dir, large_dataset)
+        self.features = x
+        x = None
+        self.labels = y_true
+        y = None
+        self.similarities = similarities
+        similarities = None
+        
 
     def __len__(self):
         return len(self.triples)

--- a/datasets/triples.py
+++ b/datasets/triples.py
@@ -7,8 +7,7 @@ from tqdm import tqdm
 def samples_triples(n_nodes, num_samples):
     num_samples = int(num_samples)
     all_nodes = np.arange(n_nodes)
-    mesh = np.array(np.meshgrid(all_nodes, all_nodes))
-    pairs = mesh.T.reshape(-1, 2)
+    pairs = np.array(np.meshgrid(all_nodes, all_nodes)).T.reshape(-1,2)
     pairs = pairs[pairs[:, 0] < pairs[:, 1]]
     n_pairs = pairs.shape[0]
     if num_samples < n_pairs:

--- a/train.py
+++ b/train.py
@@ -55,8 +55,8 @@ def train(args):
         torch.set_default_dtype(torch.float64)
 
     # create dataset
-    x, y_true, similarities = load_data(args.dataset)
-    dataset = HCDataset(x, y_true, similarities, num_samples=args.num_samples)
+    dataset = HCDataset(args.data_points, args.num_samples, args.dataset, args.large_dataset)
+    similarities = dataset.similarities 
     dataloader = data.DataLoader(dataset, batch_size=args.batch_size, shuffle=True, num_workers=8, pin_memory=True)
 
     # create model

--- a/visualize.py
+++ b/visualize.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     # load dataset
     config = json.load(open(os.path.join(args.model_dir, "config.json")))
     config_args = argparse.Namespace(**config)
-    _, y_true, similarities = load_data(config_args.dataset)
+    _, y_true, similarities = load_data(config_args.dataset, config_args.large_dataset)
 
     # build HypHC model
     model = HypHC(similarities.shape[0], config_args.rank, config_args.temperature, config_args.init_size,


### PR DESCRIPTION
Our paper was recently accepted at WI-IAT and will be published soon, here is the arxiv version:(https://arxiv.org/abs/2110.15923)

We leverage HypHC in our work to reduce the dimensions. Our dataset had 59260 data points, each of dimension 600. The current version of the code is giving out of memory errors in the pre-training stage itself. By moving some lines around, and rewriting sections of the code, we were able to keep the same functionality of the code and train the model for our dataset.

I have included two additional arguments in the config file:
* "large_dataset": should be set to 1 if the dataset is large, otherwise 0. In the case of large datasets, some matrix multiplications are replaced with loops, which make the code a bit slower (hence the argument is provided)
* "data_points": the number of data points in the dataset, would be the number of lines in the .data file in the `data` directory